### PR TITLE
Correction of the comparators used in tests

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -145,9 +145,9 @@ describe('observable array tests', function () {
     });
     it('will replicate .sort', function () {
         var obj = obs.observeArray([1, 2, 3, 4, 5]);
-        obj.sort(function (l, r) { return l < r; });
+        obj.sort(function (l, r) { return l < r ? 1 : (l > r ? -1 : 0); });
         expect(obj.join('')).to.equal('54321');
-        obj.sort(function (l, r) { return l > r; });
+        obj.sort(function (l, r) { return l > r ? 1 : (l < r ? -1 : 0); });
         expect(obj.join('')).to.equal('12345');
     });
 });

--- a/test/index.ts
+++ b/test/index.ts
@@ -201,9 +201,9 @@ describe('observable array tests', () => {
     it('will replicate .sort', () => {
         var obj = obs.observeArray([1, 2, 3, 4, 5]);
 
-        obj.sort((l, r) => l < r);
+        obj.sort((l, r) => l < r ? 1 : (l > r ? -1 : 0));
         expect(obj.join('')).to.equal('54321');
-        obj.sort((l, r) => l > r);
+        obj.sort((l, r) => l > r ? 1 : (l < r ? -1 : 0));
         expect(obj.join('')).to.equal('12345');
     });
 


### PR DESCRIPTION
This PR fixes two comparators used in tests. The comparators returned boolean but they should return a number, see https://tc39.github.io/ecma262/#sec-array.prototype.sort It was a pure coincidence that the tests were passing.